### PR TITLE
Posit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 Rust library for simulating number systems.
 
 Supports IEEE-754 floating-point numbers, fixed-point numbers, and more.
-Inspired by [FPCore](https://fpbench.org/) and
-  Bill Zorn's [Titanic](https://github.com/billzorn/titanic) library.
+Inspired by [FPCore](https://fpbench.org/) and the [Titanic](https://github.com/billzorn/titanic) library.
 
 This library is hosted as a crate [here](https://crates.io/crates/mpmfnum).
 The documentation can be found [here](https://docs.rs/mpmfnum/latest/mpmfnum/).

--- a/src/ieee754/number.rs
+++ b/src/ieee754/number.rs
@@ -168,7 +168,7 @@ impl IEEE754 {
     }
 
     /// Converts this [`IEEE754`] to an [`Integer`] representing an IEEE 754 bitpattern.
-    pub fn into_bits(&self) -> Integer {
+    pub fn into_bits(self) -> Integer {
         let nbits = self.ctx.nbits();
         let (s, unsigned) = match &self.num {
             IEEE754Val::Zero(s) => (*s, Integer::zero()),

--- a/src/ieee754/round.rs
+++ b/src/ieee754/round.rs
@@ -238,7 +238,7 @@ impl IEEE754Context {
         let m = b.bitand(bitmask(p - 1));
 
         // case split by classification
-        let e_norm = e - self.emax();
+        let e_norm = e.to_isize().unwrap() - self.emax();
         let num = if e_norm < self.emin() {
             // subnormal or zero
             if m.is_zero() {
@@ -251,7 +251,7 @@ impl IEEE754Context {
         } else if e_norm <= self.emax() {
             // normal
             let c = (Integer::from(1) << (p - 1)).bitor(m);
-            let exp = e_norm.to_isize().unwrap() - (p as isize - 1);
+            let exp = e_norm - (p as isize - 1);
             IEEE754Val::Normal(s, exp, c)
         } else {
             // non-real

--- a/src/ieee754/round.rs
+++ b/src/ieee754/round.rs
@@ -1,6 +1,5 @@
-use std::ops::{BitAnd, BitOr};
-
 use rug::Integer;
+use std::ops::{BitAnd, BitOr};
 
 use crate::ieee754::{Exceptions, IEEE754Val, IEEE754};
 use crate::rfloat::{RFloat, RFloatContext};
@@ -61,11 +60,12 @@ impl IEEE754Context {
             es
         );
         assert!(
-            nbits >= es + 3,
+            nbits >= es + Self::PREC_MIN,
             "total bitwidth needs to be at least {} bits, given {} bits",
-            es + 3,
+            es + Self::PREC_MIN,
             nbits
         );
+
         Self {
             es,
             nbits,
@@ -97,9 +97,7 @@ impl IEEE754Context {
 
     /// Returns the exponent bitwidth of the format produced by
     /// this context (when viewed as a bitvector). This is guaranteed
-    /// to satisfy `2 <= self.es() <= self.nbits() - 2. Exponent
-    /// overflowing will likely occur past 60 bits, but MPFR generally
-    /// has a limit at 31 bits.
+    /// to satisfy `2 <= self.es() < self.nbits() - 2.
     pub fn es(&self) -> usize {
         self.es
     }
@@ -121,7 +119,7 @@ impl IEEE754Context {
 
     /// Returns the total bitwidth of the format produced by this context
     /// (when viewed as a bitvector). This is guaranteed to satisfy
-    /// `self.es() + 2 <= self.nbits()`.
+    /// `self.es() + 2 < self.nbits()`.
     pub fn nbits(&self) -> usize {
         self.nbits
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub mod float;
 pub mod ieee754;
 pub mod math;
 pub mod ops;
+pub mod posit;
 pub mod real;
 pub mod rfloat;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,10 @@
 //!     rounds a [`Real`] value to a floating-point number as described by
 //!     the IEEE 754 standard,
 //!  - [`FixedContext`][crate::fixed::FixedContext]
-//!     rounds a [`Real`] value to a fixed-point numbers.
-//!
-//! Planned support for posits and more!
+//!     rounds a [`Real`] value to a fixed-point numbers,
+//!  - [`PositContext`][crate::posit::PositContext]
+//!     rounds a [`Real`] value to a posit number as described
+//!     by the Posit standard.
 //!
 
 pub mod fixed;

--- a/src/posit/mod.rs
+++ b/src/posit/mod.rs
@@ -1,0 +1,12 @@
+//! "Posit" numbers as described in the 2022 Posit Standard.
+//!
+//! This module implements posits with [`PositContext`].
+//! The associated storage type is [`Posit`] which represents
+//! a posit number.
+
+mod number;
+mod round;
+
+pub use number::Posit;
+pub(crate) use number::PositVal;
+pub use round::PositContext;

--- a/src/posit/mod.rs
+++ b/src/posit/mod.rs
@@ -5,8 +5,10 @@
 //! a posit number.
 
 mod number;
+mod ops;
 mod round;
 
 pub use number::Posit;
 pub(crate) use number::PositVal;
+pub use ops::*;
 pub use round::PositContext;

--- a/src/posit/number.rs
+++ b/src/posit/number.rs
@@ -1,0 +1,130 @@
+use rug::Integer;
+
+use crate::{rfloat::RFloat, Real};
+
+use super::PositContext;
+
+/// Posit number encoding viewed as an enumeration.
+/// Unlike [`Posit`], [`PositVal`] represents only numerical data.
+#[derive(Clone, Debug)]
+pub enum PositVal {
+    /// Exact zero
+    Zero,
+    /// Finite, non-zero value
+    NonZero(bool, isize, isize, Integer),
+    /// Non-real or undefined
+    Nar,
+}
+
+/// Posit number format.
+///
+/// The associated [`RoundingContext`][crate::RoundingContext]
+/// implementation is [`PositContext`].
+/// See [`PositContext`] for more details on numerical properties
+/// of the [`Posit`] type.
+#[derive(Clone, Debug)]
+pub struct Posit {
+    pub(crate) num: PositVal,
+    pub(crate) ctx: PositContext,
+}
+
+impl Posit {
+    /// Returns the rounding context under which this number was created.
+    pub fn ctx(&self) -> &PositContext {
+        &self.ctx
+    }
+}
+
+impl Real for Posit {
+    fn radix() -> usize {
+        2
+    }
+
+    fn sign(&self) -> bool {
+        self.is_negative().unwrap_or(false)
+    }
+
+    fn exp(&self) -> Option<isize> {
+        match &self.num {
+            PositVal::Zero => None,
+            PositVal::NonZero(_, r, exp, _) => Some((r * self.ctx.useed()) + exp),
+            PositVal::Nar => None,
+        }
+    }
+
+    fn e(&self) -> Option<isize> {
+        match &self.num {
+            PositVal::Zero => None,
+            PositVal::NonZero(_, r, exp, c) => {
+                Some(((r * self.ctx.useed()) + exp - 1) + (c.significant_bits() as isize))
+            }
+            PositVal::Nar => None,
+        }
+    }
+
+    fn n(&self) -> Option<isize> {
+        match &self.num {
+            PositVal::Zero => None,
+            PositVal::NonZero(_, r, exp, _) => Some((r * self.ctx.useed()) + exp - 1),
+            PositVal::Nar => None,
+        }
+    }
+
+    fn c(&self) -> Option<Integer> {
+        match &self.num {
+            PositVal::Zero => None,
+            PositVal::NonZero(_, _, _, c) => Some(c.clone()),
+            PositVal::Nar => None,
+        }
+    }
+
+    fn m(&self) -> Option<Integer> {
+        self.c().map(|c| if self.sign() { -c } else { c })
+    }
+
+    fn p(&self) -> usize {
+        match &self.num {
+            PositVal::Zero => 0,
+            PositVal::NonZero(_, _, _, c) => c.significant_bits() as usize,
+            PositVal::Nar => 0,
+        }
+    }
+
+    fn is_nar(&self) -> bool {
+        matches!(self.num, PositVal::Nar)
+    }
+
+    fn is_finite(&self) -> bool {
+        !matches!(self.num, PositVal::Nar)
+    }
+
+    fn is_infinite(&self) -> bool {
+        false
+    }
+
+    fn is_zero(&self) -> bool {
+        matches!(self.num, PositVal::Zero)
+    }
+
+    fn is_negative(&self) -> Option<bool> {
+        match &self.num {
+            PositVal::Zero => None,
+            PositVal::NonZero(s, _, _, _) => Some(*s),
+            PositVal::Nar => None,
+        }
+    }
+
+    fn is_numerical(&self) -> bool {
+        !matches!(self.num, PositVal::Nar)
+    }
+}
+
+impl From<Posit> for RFloat {
+    fn from(value: Posit) -> Self {
+        match value.num {
+            PositVal::Zero => RFloat::zero(),
+            PositVal::NonZero(s, r, exp, c) => RFloat::Real(s, value.ctx.rscale() * r + exp, c),
+            PositVal::Nar => RFloat::Nan,
+        }
+    }
+}

--- a/src/posit/ops.rs
+++ b/src/posit/ops.rs
@@ -1,0 +1,118 @@
+use crate::math::*;
+use crate::ops::*;
+use crate::posit::PositContext;
+use crate::rfloat::RFloat;
+use crate::{Real, RoundingContext};
+
+macro_rules! rounded_1ary_impl {
+    ($tname:ident, $name:ident, $mpmf:ident, $mpfr:ident) => {
+        impl $tname for PositContext {
+            fn $mpmf<N: Real>(&self, src: &N) -> Self::Rounded {
+                // compute with 2 additional bits, rounding-to-odd
+                let p = self.max_p() + 2;
+                let r = RFloat::from_number(src);
+                let result = $mpfr(r, p);
+                self.round(result.num())
+            }
+        }
+    };
+}
+
+rounded_1ary_impl!(RoundedNeg, format_neg, neg, mpfr_neg);
+rounded_1ary_impl!(RoundedAbs, format_abs, abs, mpfr_abs);
+rounded_1ary_impl!(RoundedSqrt, format_sqrt, sqrt, mpfr_sqrt);
+rounded_1ary_impl!(RoundedCbrt, format_cbrt, cbrt, mpfr_cbrt);
+rounded_1ary_impl!(RoundedRecip, format_recip, recip, mpfr_recip);
+rounded_1ary_impl!(
+    RoundedRecipSqrt,
+    format_recip_sqrt,
+    recip_sqrt,
+    mpfr_recip_sqrt
+);
+rounded_1ary_impl!(RoundedExp, format_exp, exp, mpfr_exp);
+rounded_1ary_impl!(RoundedExp2, format_exp2, exp2, mpfr_exp2);
+rounded_1ary_impl!(RoundedLog, format_log, log, mpfr_log);
+rounded_1ary_impl!(RoundedLog2, format_log2, log2, mpfr_log2);
+rounded_1ary_impl!(RoundedLog10, format_log10, log10, mpfr_log10);
+rounded_1ary_impl!(RoundedExpm1, format_expm1, expm1, mpfr_expm1);
+rounded_1ary_impl!(RoundedExp2m1, format_exp2m1, exp2m1, mpfr_exp2m1);
+rounded_1ary_impl!(RoundedExp10m1, format_exp10m1, exp10m1, mpfr_exp10m1);
+rounded_1ary_impl!(RoundedLog1p, format_log1p, log1p, mpfr_log1p);
+rounded_1ary_impl!(RoundedLog2p1, format_log2p1, log2p1, mpfr_log2p1);
+rounded_1ary_impl!(RoundedLog10p1, format_log10p1, log10p1, mpfr_log10p1);
+rounded_1ary_impl!(RoundedSin, format_sin, sin, mpfr_sin);
+rounded_1ary_impl!(RoundedCos, format_cos, cos, mpfr_cos);
+rounded_1ary_impl!(RoundedTan, format_tan, tan, mpfr_tan);
+rounded_1ary_impl!(RoundedSinPi, format_sin_pi, sin_pi, mpfr_sin_pi);
+rounded_1ary_impl!(RoundedCosPi, format_cos_pi, cos_pi, mpfr_cos_pi);
+rounded_1ary_impl!(RoundedTanPi, format_tan_pi, tan_pi, mpfr_tan_pi);
+rounded_1ary_impl!(RoundedAsin, format_asin, asin, mpfr_asin);
+rounded_1ary_impl!(RoundedAcos, format_acos, acos, mpfr_acos);
+rounded_1ary_impl!(RoundedAtan, format_atan, atan, mpfr_atan);
+rounded_1ary_impl!(RoundedSinh, format_sinh, sinh, mpfr_sinh);
+rounded_1ary_impl!(RoundedCosh, format_cosh, cosh, mpfr_cosh);
+rounded_1ary_impl!(RoundedTanh, format_tanh, tanh, mpfr_tanh);
+rounded_1ary_impl!(RoundedAsinh, format_asinh, asinh, mpfr_asinh);
+rounded_1ary_impl!(RoundedAcosh, format_acosh, acosh, mpfr_acosh);
+rounded_1ary_impl!(RoundedAtanh, format_atanh, atanh, mpfr_atanh);
+rounded_1ary_impl!(RoundedErf, format_erf, erf, mpfr_erf);
+rounded_1ary_impl!(RoundedErfc, format_erfc, erfc, mpfr_erfc);
+rounded_1ary_impl!(RoundedGamma, format_tgamma, tgamma, mpfr_tgamma);
+rounded_1ary_impl!(RoundedLgamma, format_lgamma, lgamma, mpfr_lgamma);
+
+macro_rules! rounded_2ary_impl {
+    ($tname:ident, $name:ident, $mpmf:ident, $mpfr:ident) => {
+        impl $tname for PositContext {
+            fn $mpmf<N1, N2>(&self, src1: &N1, src2: &N2) -> Self::Rounded
+            where
+                N1: Real,
+                N2: Real,
+            {
+                // compute with 2 additional bits, rounding-to-odd
+                let p = self.max_p() + 2;
+                let r1 = RFloat::from_number(src1);
+                let r2 = RFloat::from_number(src2);
+                let result = $mpfr(r1, r2, p);
+                self.round(result.num())
+            }
+        }
+    };
+}
+
+rounded_2ary_impl!(RoundedAdd, format_add, add, mpfr_add);
+rounded_2ary_impl!(RoundedSub, format_sub, sub, mpfr_sub);
+rounded_2ary_impl!(RoundedMul, format_mul, mul, mpfr_mul);
+rounded_2ary_impl!(RoundedDiv, format_div, div, mpfr_div);
+rounded_2ary_impl!(RoundedPow, format_pow, pow, mpfr_pow);
+rounded_2ary_impl!(RoundedHypot, format_hypot, hypot, mpfr_hypot);
+rounded_2ary_impl!(RoundedFmod, format_fmod, fmod, mpfr_fmod);
+rounded_2ary_impl!(
+    RoundedRemainder,
+    format_remainder,
+    remainder,
+    mpfr_remainder
+);
+rounded_2ary_impl!(RoundedAtan2, format_atan2, atan2, mpfr_atan2);
+
+macro_rules! rounded_3ary_impl {
+    ($tname:ident, $name:ident, $mpmf:ident, $mpfr:ident) => {
+        impl $tname for PositContext {
+            fn $mpmf<N1, N2, N3>(&self, src1: &N1, src2: &N2, src3: &N3) -> Self::Rounded
+            where
+                N1: Real,
+                N2: Real,
+                N3: Real,
+            {
+                // compute with 2 additional bits, rounding-to-odd
+                let p = self.max_p() + 2;
+                let r1 = RFloat::from_number(src1);
+                let r2 = RFloat::from_number(src2);
+                let r3 = RFloat::from_number(src3);
+                let result = $mpfr(r1, r2, r3, p);
+                self.round(result.num())
+            }
+        }
+    };
+}
+
+rounded_3ary_impl!(RoundedFMA, format_fma, fma, mpfr_fma);

--- a/src/posit/round.rs
+++ b/src/posit/round.rs
@@ -1,0 +1,152 @@
+use rug::Integer;
+
+use crate::{Real, RoundingContext};
+
+use super::{Posit, PositVal};
+
+/// Rounding contexts for posit numbers.
+///
+/// The associated storage type is [`Posit`].
+///
+/// Values rounded under this context are posit numbers as described
+/// by the Posit standard: base 2 scientific numbers:
+/// `(-1)^s * c * 2^e * (2^2^es)^r` where `c` is an unsigned integer,
+/// `r` and `e` are integers. The key property of posit numbers
+/// is that the precision of `c` and `e` change based on the value
+/// of `r`. In general, `c` and `e` are large when `r` is near 0
+/// and small (or zero) when `r` is large or small. In posit terminology,
+/// the value `2^2^es` is called `useed`.
+///
+/// A [`PositContext`] is parameterized by
+///
+///  - maximum bitwidth of the exponent field
+///  - total bitwidth of the encoding
+///
+/// For values in between the largest and smallest magnitude,
+/// [`NearestTiesToEven`][RoundingDirection::NearestTiesToEven].
+/// Otherwise, the values are flushed to `NAR`.
+#[derive(Clone, Debug)]
+pub struct PositContext {
+    es: usize,
+    nbits: usize,
+}
+
+impl PositContext {
+    /// Implementation limit: maximum exponent size
+    pub const ES_MAX: usize = 32;
+    /// Implementation limit: minimum additional bitwidth,
+    pub const PAD_MIN: usize = 3;
+
+    pub fn new(es: usize, nbits: usize) -> Self {
+        assert!(
+            es <= Self::ES_MAX,
+            "exponent width needs to be at most {} bits, given {} bits",
+            Self::ES_MAX,
+            es
+        );
+        assert!(
+            nbits >= es + Self::PAD_MIN,
+            "total bitwidth needs to be at least {} bits, given {} bits",
+            es + Self::PAD_MIN,
+            nbits
+        );
+
+        Self { es, nbits }
+    }
+
+    /// Returns the regime bitwidth of the format produced by
+    /// this context (when viewed as a bitvector). This is guaranteed
+    /// to satisfy `2 <= self.es() < self.nbits() - 2.
+    pub fn es(&self) -> usize {
+        self.es
+    }
+
+    /// Returns the total bitwidth of the format produced by this context
+    /// (when viewed as a bitvector). This is guaranteed to satisfy
+    /// `self.es() + 2 < self.nbits()`.
+    pub fn nbits(&self) -> usize {
+        self.nbits
+    }
+
+    /// Returns the maximum precision allowed by this format.
+    pub fn max_p(&self) -> usize {
+        self.nbits - self.es - 3
+    }
+
+    /// Posit terminology for `2^2^es`
+    pub fn useed(&self) -> isize {
+        (1_usize << (1 << self.es)) as isize
+    }
+
+    /// The exponent scale `2^es`
+    pub fn rscale(&self) -> isize {
+        (1 << self.es) as isize
+    }
+
+    /// Largest representable regime
+    pub fn rmax(&self) -> isize {
+        let max_r = (self.nbits - 1) as isize;
+        max_r - 1
+    }
+
+    /// Largest representable regime
+    pub fn rmin(&self) -> isize {
+        let max_r = (self.nbits - 1) as isize;
+        1 - max_r
+    }
+
+    /// Largest representable (normalized) exponent
+    pub fn emax(&self) -> isize {
+        // format only contains regime bits
+        self.rscale() * self.rmax()
+    }
+
+    /// Smallest representable (unnormalized) exponent
+    pub fn expmax(&self) -> isize {
+        // format only contains regime bits
+        self.emax()
+    }
+
+    /// Smallest representable (normalized) exponent
+    pub fn emin(&self) -> isize {
+        // format only contains regime bits
+        self.rscale() * self.rmin()
+    }
+
+    /// Largest representable (unnormalized) exponent
+    pub fn expmin(&self) -> isize {
+        self.emin() // precision is 1 bit
+    }
+
+    /// Maximum representable value
+    pub fn maxval(&self) -> Posit {
+        Posit {
+            num: PositVal::NonZero(false, self.rmax(), 0, Integer::from(1)),
+            ctx: self.clone(),
+        }
+    }
+
+    /// Minimum representable value
+    pub fn minval(&self) -> Posit {
+        Posit {
+            num: PositVal::NonZero(false, self.rmin(), 0, Integer::from(1)),
+            ctx: self.clone(),
+        }
+    }
+
+    /// Constructs zero in this format.
+    pub fn zero(&self) -> Posit {
+        Posit {
+            num: PositVal::Zero,
+            ctx: self.clone(),
+        }
+    }
+}
+
+impl RoundingContext for PositContext {
+    type Rounded = Posit;
+
+    fn round<T: Real>(&self, val: &T) -> Self::Rounded {
+        todo!()
+    }
+}

--- a/src/posit/round.rs
+++ b/src/posit/round.rs
@@ -1,6 +1,8 @@
 use rug::Integer;
 
-use crate::{rfloat::RFloatContext, util::bitmask, Real, RoundingContext, RoundingMode};
+use crate::rfloat::RFloatContext;
+use crate::util::bitmask;
+use crate::{Real, RoundingContext, RoundingMode};
 
 use super::{Posit, PositVal};
 
@@ -23,7 +25,7 @@ use super::{Posit, PositVal};
 ///  - total bitwidth of the encoding
 ///
 /// For values in between the largest and smallest magnitude,
-/// [`NearestTiesToEven`][RoundingDirection::NearestTiesToEven].
+/// [`NearestTiesToEven`][RoundingMode::NearestTiesToEven].
 /// Otherwise, the values are flushed to `NAR`.
 #[derive(Clone, Debug)]
 pub struct PositContext {

--- a/src/posit/round.rs
+++ b/src/posit/round.rs
@@ -146,7 +146,7 @@ impl PositContext {
         }
     }
 
-    /// Converts an [`Integer`] representing a posit number into
+    /// Converts an [`Integer`] representing a posit bitpattern into
     /// a [`Posit`] value under this [`PositContext`].
     pub fn bits_to_number(&self, b: Integer) -> Posit {
         let limit = Integer::from(1) << self.nbits;
@@ -189,7 +189,7 @@ impl PositContext {
                 };
 
                 // extract bits
-                let efield = ((ns.clone() >> mbits) & bitmask(ebits)).to_isize().unwrap();
+                let efield = (ns.clone() >> mbits) & bitmask(ebits);
                 let mfield = ns & bitmask(mbits);
 
                 // convert regime
@@ -202,9 +202,9 @@ impl PositContext {
 
                 // convert exponent
                 let e = if ebits < self.es {
-                    efield << (self.es - ebits)
+                    efield.to_isize().unwrap() << (self.es - ebits)
                 } else {
-                    efield
+                    efield.to_isize().unwrap()
                 };
 
                 // convert significand

--- a/tests/posit.rs
+++ b/tests/posit.rs
@@ -1,8 +1,6 @@
 use mpmfnum::{posit::*, rfloat::RFloat, Real};
 use rug::Integer;
 
-
-
 fn bits_to_rfloat(ctx: &PositContext, i: usize) -> RFloat {
     RFloat::from(ctx.bits_to_number(Integer::from(i)))
 }
@@ -13,84 +11,69 @@ fn enumerate() {
     let ctx = PositContext::new(2, 6);
     let all_vals = [
         RFloat::zero(),
-        RFloat::Real(false, -16, Integer::from(1)),     // (false, -4, 0, 1)
-
-        RFloat::Real(false, -12, Integer::from(1)),     // (false, -3, 0, 1)
-        RFloat::Real(false, -10, Integer::from(1)),     // (false, -3, 2, 1)
-
-        RFloat::Real(false, -8, Integer::from(1)),      // (false, -2, 0, 1)
-        RFloat::Real(false, -7, Integer::from(1)),      // (false, -2, 1, 1)
-        RFloat::Real(false, -6, Integer::from(1)),      // (false, -2, 2, 1)
-        RFloat::Real(false, -5, Integer::from(1)),      // (false, -2, 3, 1)
-
-        RFloat::Real(false, -5, Integer::from(2)),      // (false, -1, -1, 2)
-        RFloat::Real(false, -5, Integer::from(3)),      // (false, -1, -1, 3)
-        RFloat::Real(false, -4, Integer::from(2)),      // (false, -1, 0, 2)
-        RFloat::Real(false, -4, Integer::from(3)),      // (false, -1, 0, 3)
-        RFloat::Real(false, -3, Integer::from(2)),      // (false, -1, 1, 2)
-        RFloat::Real(false, -3, Integer::from(3)),      // (false, -1, 1, 3)
-        RFloat::Real(false, -2, Integer::from(2)),      // (false, -1, 2, 2)
-        RFloat::Real(false, -2, Integer::from(3)),      // (false, -1, 2, 3)
-
-        RFloat::Real(false, -1, Integer::from(2)),      // (false, 0, -1, 2)
-        RFloat::Real(false, -1, Integer::from(3)),      // (false, 0, -1, 3)
-        RFloat::Real(false, 0, Integer::from(2)),       // (false, 0, 0, 2)
-        RFloat::Real(false, 0, Integer::from(3)),       // (false, 0, 0, 3)
-        RFloat::Real(false, 1, Integer::from(2)),       // (false, 0, 1, 2)
-        RFloat::Real(false, 1, Integer::from(3)),       // (false, 0, 1, 3)
-        RFloat::Real(false, 2, Integer::from(2)),       // (false, 0, 2, 2)
-        RFloat::Real(false, 2, Integer::from(3)),       // (false, 0, 2, 3)
-
-        RFloat::Real(false, 4, Integer::from(1)),       // (false, 1, 0, 1)
-        RFloat::Real(false, 5, Integer::from(1)),       // (false, 1, 1, 1)
-        RFloat::Real(false, 6, Integer::from(1)),       // (false, 1, 2, 1)
-        RFloat::Real(false, 7, Integer::from(1)),       // (false, 1, 3, 1)
-
-        RFloat::Real(false, 8, Integer::from(1)),       // (false, 2, 0, 1)
-        RFloat::Real(false, 10, Integer::from(1)),      // (false, 2, 2, 1)
-
-        RFloat::Real(false, 12, Integer::from(1)),      // (false, 3, 0, 1)
-        RFloat::Real(false, 16, Integer::from(1)),      // (false, 4, 0, 1)
-
+        RFloat::Real(false, -16, Integer::from(1)), // (false, -4, 0, 1)
+        RFloat::Real(false, -12, Integer::from(1)), // (false, -3, 0, 1)
+        RFloat::Real(false, -10, Integer::from(1)), // (false, -3, 2, 1)
+        RFloat::Real(false, -8, Integer::from(1)),  // (false, -2, 0, 1)
+        RFloat::Real(false, -7, Integer::from(1)),  // (false, -2, 1, 1)
+        RFloat::Real(false, -6, Integer::from(1)),  // (false, -2, 2, 1)
+        RFloat::Real(false, -5, Integer::from(1)),  // (false, -2, 3, 1)
+        RFloat::Real(false, -5, Integer::from(2)),  // (false, -1, -1, 2)
+        RFloat::Real(false, -5, Integer::from(3)),  // (false, -1, -1, 3)
+        RFloat::Real(false, -4, Integer::from(2)),  // (false, -1, 0, 2)
+        RFloat::Real(false, -4, Integer::from(3)),  // (false, -1, 0, 3)
+        RFloat::Real(false, -3, Integer::from(2)),  // (false, -1, 1, 2)
+        RFloat::Real(false, -3, Integer::from(3)),  // (false, -1, 1, 3)
+        RFloat::Real(false, -2, Integer::from(2)),  // (false, -1, 2, 2)
+        RFloat::Real(false, -2, Integer::from(3)),  // (false, -1, 2, 3)
+        RFloat::Real(false, -1, Integer::from(2)),  // (false, 0, -1, 2)
+        RFloat::Real(false, -1, Integer::from(3)),  // (false, 0, -1, 3)
+        RFloat::Real(false, 0, Integer::from(2)),   // (false, 0, 0, 2)
+        RFloat::Real(false, 0, Integer::from(3)),   // (false, 0, 0, 3)
+        RFloat::Real(false, 1, Integer::from(2)),   // (false, 0, 1, 2)
+        RFloat::Real(false, 1, Integer::from(3)),   // (false, 0, 1, 3)
+        RFloat::Real(false, 2, Integer::from(2)),   // (false, 0, 2, 2)
+        RFloat::Real(false, 2, Integer::from(3)),   // (false, 0, 2, 3)
+        RFloat::Real(false, 4, Integer::from(1)),   // (false, 1, 0, 1)
+        RFloat::Real(false, 5, Integer::from(1)),   // (false, 1, 1, 1)
+        RFloat::Real(false, 6, Integer::from(1)),   // (false, 1, 2, 1)
+        RFloat::Real(false, 7, Integer::from(1)),   // (false, 1, 3, 1)
+        RFloat::Real(false, 8, Integer::from(1)),   // (false, 2, 0, 1)
+        RFloat::Real(false, 10, Integer::from(1)),  // (false, 2, 2, 1)
+        RFloat::Real(false, 12, Integer::from(1)),  // (false, 3, 0, 1)
+        RFloat::Real(false, 16, Integer::from(1)),  // (false, 4, 0, 1)
         RFloat::Nan,
-        RFloat::Real(true, -16, Integer::from(1)),      // (true, -4, 0, 1)
-
-        RFloat::Real(true, -12, Integer::from(1)),      // (true, -3, 0, 1)
-        RFloat::Real(true, -10, Integer::from(1)),      // (true, -3, 2, 1)
-
-        RFloat::Real(true, -8, Integer::from(1)),       // (true, -2, 0, 1)
-        RFloat::Real(true, -7, Integer::from(1)),       // (true, -2, 1, 1)
-        RFloat::Real(true, -6, Integer::from(1)),       // (true, -2, 2, 1)
-        RFloat::Real(true, -5, Integer::from(1)),       // (true, -2, 3, 1)
-
-        RFloat::Real(true, -5, Integer::from(2)),       // (true, -1, -1, 2)
-        RFloat::Real(true, -5, Integer::from(3)),       // (true, -1, -1, 3)
-        RFloat::Real(true, -4, Integer::from(2)),       // (true, -1, 0, 2)
-        RFloat::Real(true, -4, Integer::from(3)),       // (true, -1, 0, 3)
-        RFloat::Real(true, -3, Integer::from(2)),       // (true, -1, 1, 2)
-        RFloat::Real(true, -3, Integer::from(3)),       // (true, -1, 1, 3)
-        RFloat::Real(true, -2, Integer::from(2)),       // (true, -1, 2, 2)
-        RFloat::Real(true, -2, Integer::from(3)),       // (true, -1, 2, 3)
-
-        RFloat::Real(true, -1, Integer::from(2)),       // (true, 0, -1, 2)
-        RFloat::Real(true, -1, Integer::from(3)),       // (true, 0, -1, 3)
-        RFloat::Real(true, 0, Integer::from(2)),        // (true, 0, 0, 2)
-        RFloat::Real(true, 0, Integer::from(3)),        // (true, 0, 0, 3)
-        RFloat::Real(true, 1, Integer::from(2)),        // (true, 0, 1, 2)
-        RFloat::Real(true, 1, Integer::from(3)),        // (true, 0, 1, 3)
-        RFloat::Real(true, 2, Integer::from(2)),        // (true, 0, 2, 2)
-        RFloat::Real(true, 2, Integer::from(3)),        // (true, 0, 2, 3)
-
-        RFloat::Real(true, 4, Integer::from(1)),         // (true, 1, 0, 1)
-        RFloat::Real(true, 5, Integer::from(1)),         // (true, 1, 1, 1)
-        RFloat::Real(true, 6, Integer::from(1)),         // (true, 1, 2, 1)
-        RFloat::Real(true, 7, Integer::from(1)),         // (true, 1, 3, 1)
-
-        RFloat::Real(true, 8, Integer::from(1)),         // (true, 2, 0, 1)
-        RFloat::Real(true, 10, Integer::from(1)),        // (true, 2, 2, 1)
-
-        RFloat::Real(true, 12, Integer::from(1)),        // (true, 3, 0, 1)
-        RFloat::Real(true, 16, Integer::from(1)),        // (true, 4, 0, 1)
+        RFloat::Real(true, -16, Integer::from(1)), // (true, -4, 0, 1)
+        RFloat::Real(true, -12, Integer::from(1)), // (true, -3, 0, 1)
+        RFloat::Real(true, -10, Integer::from(1)), // (true, -3, 2, 1)
+        RFloat::Real(true, -8, Integer::from(1)),  // (true, -2, 0, 1)
+        RFloat::Real(true, -7, Integer::from(1)),  // (true, -2, 1, 1)
+        RFloat::Real(true, -6, Integer::from(1)),  // (true, -2, 2, 1)
+        RFloat::Real(true, -5, Integer::from(1)),  // (true, -2, 3, 1)
+        RFloat::Real(true, -5, Integer::from(2)),  // (true, -1, -1, 2)
+        RFloat::Real(true, -5, Integer::from(3)),  // (true, -1, -1, 3)
+        RFloat::Real(true, -4, Integer::from(2)),  // (true, -1, 0, 2)
+        RFloat::Real(true, -4, Integer::from(3)),  // (true, -1, 0, 3)
+        RFloat::Real(true, -3, Integer::from(2)),  // (true, -1, 1, 2)
+        RFloat::Real(true, -3, Integer::from(3)),  // (true, -1, 1, 3)
+        RFloat::Real(true, -2, Integer::from(2)),  // (true, -1, 2, 2)
+        RFloat::Real(true, -2, Integer::from(3)),  // (true, -1, 2, 3)
+        RFloat::Real(true, -1, Integer::from(2)),  // (true, 0, -1, 2)
+        RFloat::Real(true, -1, Integer::from(3)),  // (true, 0, -1, 3)
+        RFloat::Real(true, 0, Integer::from(2)),   // (true, 0, 0, 2)
+        RFloat::Real(true, 0, Integer::from(3)),   // (true, 0, 0, 3)
+        RFloat::Real(true, 1, Integer::from(2)),   // (true, 0, 1, 2)
+        RFloat::Real(true, 1, Integer::from(3)),   // (true, 0, 1, 3)
+        RFloat::Real(true, 2, Integer::from(2)),   // (true, 0, 2, 2)
+        RFloat::Real(true, 2, Integer::from(3)),   // (true, 0, 2, 3)
+        RFloat::Real(true, 4, Integer::from(1)),   // (true, 1, 0, 1)
+        RFloat::Real(true, 5, Integer::from(1)),   // (true, 1, 1, 1)
+        RFloat::Real(true, 6, Integer::from(1)),   // (true, 1, 2, 1)
+        RFloat::Real(true, 7, Integer::from(1)),   // (true, 1, 3, 1)
+        RFloat::Real(true, 8, Integer::from(1)),   // (true, 2, 0, 1)
+        RFloat::Real(true, 10, Integer::from(1)),  // (true, 2, 2, 1)
+        RFloat::Real(true, 12, Integer::from(1)),  // (true, 3, 0, 1)
+        RFloat::Real(true, 16, Integer::from(1)),  // (true, 4, 0, 1)
     ];
 
     for (i, v) in all_vals.iter().enumerate() {
@@ -98,8 +81,19 @@ fn enumerate() {
         if num.is_nar() {
             assert!(v.is_nar(), "failed conversion: i={}, v=NAR, e={:?}", i, v);
         } else {
-            assert_eq!(num.clone(), v.clone(), "failed conversion: i={}, v={:?}, e={:?}", i, num, v);
+            assert_eq!(
+                num.clone(),
+                v.clone(),
+                "failed conversion: i={}, v={:?}, e={:?}",
+                i,
+                num,
+                v
+            );
         }
+
+        let f = ctx.bits_to_number(Integer::from(i));
+        let j = f.into_bits();
+        assert_eq!(i, j, "failed round-trip: i={}, j={}, v={:?}", i, j, num);
     }
 }
 

--- a/tests/posit.rs
+++ b/tests/posit.rs
@@ -172,17 +172,40 @@ fn round_small() {
     assert!(rounded_zero.is_zero(), "round(+0) = +0");
 
     // rounding MAXVAL + 1
-    let maxp1 = RFloat::one() + RFloat::from(ctx.maxval(false));
+    let maxp1 = RFloat::from(ctx.maxval(false)) + RFloat::one();
     let rounded_maxp1 = ctx.round(&maxp1);
     assert_eq!(rounded_maxp1, ctx.maxval(false), "round(MAXVAL+1) = MAXVAL");
+
+    // rounding MINVAL + 1
+    let minval = RFloat::from(ctx.minval(false));
+    let tiny = RFloat::Real(
+        minval.sign(),
+        minval.exp().unwrap() - 1,
+        minval.c().unwrap(),
+    );
+    let rounded_tiny = ctx.round(&tiny);
+    assert_eq!(
+        rounded_tiny,
+        ctx.minval(false),
+        "rouned(MINVAL * 2^-1, MINVAL)"
+    );
 
     // rounding +1
     let one = RFloat::one();
     let rounded_one = ctx.round(&one);
-    assert_eq!(one, RFloat::from(rounded_one), "round(+1) = +1");
+    assert_eq!(RFloat::from(rounded_one), one, "round(+1) = +1");
 
     // rounding +1.0625
     let one_1_16 = RFloat::Real(false, -4, Integer::from(17));
     let rounded = ctx.round(&one_1_16);
-    assert_eq!(one, RFloat::from(rounded), "round(+1.0625) = +1");
+    assert_eq!(RFloat::from(rounded), one, "round(+1.0625) = +1");
+
+    // rounding +1.1875
+    let one_3_16 = RFloat::Real(false, -4, Integer::from(19));
+    let rounded = ctx.round(&one_3_16);
+    assert_eq!(
+        RFloat::from(rounded),
+        RFloat::Real(false, -4, Integer::from(20)),
+        "round(+1.1875) = +1.25"
+    );
 }

--- a/tests/posit.rs
+++ b/tests/posit.rs
@@ -1,11 +1,119 @@
-use mpmfnum::{posit::*, rfloat::RFloat};
+use mpmfnum::{posit::*, rfloat::RFloat, Real};
 use rug::Integer;
+
+
+
+fn bits_to_rfloat(ctx: &PositContext, i: usize) -> RFloat {
+    RFloat::from(ctx.bits_to_number(Integer::from(i)))
+}
 
 #[test]
 fn enumerate() {
-    // "Posit8" format
+    // posit<2, 6> format
+    let ctx = PositContext::new(2, 6);
+    let all_vals = [
+        RFloat::zero(),
+        RFloat::Real(false, -16, Integer::from(1)),     // (false, -4, 0, 1)
+
+        RFloat::Real(false, -12, Integer::from(1)),     // (false, -3, 0, 1)
+        RFloat::Real(false, -10, Integer::from(1)),     // (false, -3, 2, 1)
+
+        RFloat::Real(false, -8, Integer::from(1)),      // (false, -2, 0, 1)
+        RFloat::Real(false, -7, Integer::from(1)),      // (false, -2, 1, 1)
+        RFloat::Real(false, -6, Integer::from(1)),      // (false, -2, 2, 1)
+        RFloat::Real(false, -5, Integer::from(1)),      // (false, -2, 3, 1)
+
+        RFloat::Real(false, -5, Integer::from(2)),      // (false, -1, -1, 2)
+        RFloat::Real(false, -5, Integer::from(3)),      // (false, -1, -1, 3)
+        RFloat::Real(false, -4, Integer::from(2)),      // (false, -1, 0, 2)
+        RFloat::Real(false, -4, Integer::from(3)),      // (false, -1, 0, 3)
+        RFloat::Real(false, -3, Integer::from(2)),      // (false, -1, 1, 2)
+        RFloat::Real(false, -3, Integer::from(3)),      // (false, -1, 1, 3)
+        RFloat::Real(false, -2, Integer::from(2)),      // (false, -1, 2, 2)
+        RFloat::Real(false, -2, Integer::from(3)),      // (false, -1, 2, 3)
+
+        RFloat::Real(false, -1, Integer::from(2)),      // (false, 0, -1, 2)
+        RFloat::Real(false, -1, Integer::from(3)),      // (false, 0, -1, 3)
+        RFloat::Real(false, 0, Integer::from(2)),       // (false, 0, 0, 2)
+        RFloat::Real(false, 0, Integer::from(3)),       // (false, 0, 0, 3)
+        RFloat::Real(false, 1, Integer::from(2)),       // (false, 0, 1, 2)
+        RFloat::Real(false, 1, Integer::from(3)),       // (false, 0, 1, 3)
+        RFloat::Real(false, 2, Integer::from(2)),       // (false, 0, 2, 2)
+        RFloat::Real(false, 2, Integer::from(3)),       // (false, 0, 2, 3)
+
+        RFloat::Real(false, 4, Integer::from(1)),       // (false, 1, 0, 1)
+        RFloat::Real(false, 5, Integer::from(1)),       // (false, 1, 1, 1)
+        RFloat::Real(false, 6, Integer::from(1)),       // (false, 1, 2, 1)
+        RFloat::Real(false, 7, Integer::from(1)),       // (false, 1, 3, 1)
+
+        RFloat::Real(false, 8, Integer::from(1)),       // (false, 2, 0, 1)
+        RFloat::Real(false, 10, Integer::from(1)),      // (false, 2, 2, 1)
+
+        RFloat::Real(false, 12, Integer::from(1)),      // (false, 3, 0, 1)
+        RFloat::Real(false, 16, Integer::from(1)),      // (false, 4, 0, 1)
+
+        RFloat::Nan,
+        RFloat::Real(true, -16, Integer::from(1)),      // (true, -4, 0, 1)
+
+        RFloat::Real(true, -12, Integer::from(1)),      // (true, -3, 0, 1)
+        RFloat::Real(true, -10, Integer::from(1)),      // (true, -3, 2, 1)
+
+        RFloat::Real(true, -8, Integer::from(1)),       // (true, -2, 0, 1)
+        RFloat::Real(true, -7, Integer::from(1)),       // (true, -2, 1, 1)
+        RFloat::Real(true, -6, Integer::from(1)),       // (true, -2, 2, 1)
+        RFloat::Real(true, -5, Integer::from(1)),       // (true, -2, 3, 1)
+
+        RFloat::Real(true, -5, Integer::from(2)),       // (true, -1, -1, 2)
+        RFloat::Real(true, -5, Integer::from(3)),       // (true, -1, -1, 3)
+        RFloat::Real(true, -4, Integer::from(2)),       // (true, -1, 0, 2)
+        RFloat::Real(true, -4, Integer::from(3)),       // (true, -1, 0, 3)
+        RFloat::Real(true, -3, Integer::from(2)),       // (true, -1, 1, 2)
+        RFloat::Real(true, -3, Integer::from(3)),       // (true, -1, 1, 3)
+        RFloat::Real(true, -2, Integer::from(2)),       // (true, -1, 2, 2)
+        RFloat::Real(true, -2, Integer::from(3)),       // (true, -1, 2, 3)
+
+        RFloat::Real(true, -1, Integer::from(2)),       // (true, 0, -1, 2)
+        RFloat::Real(true, -1, Integer::from(3)),       // (true, 0, -1, 3)
+        RFloat::Real(true, 0, Integer::from(2)),        // (true, 0, 0, 2)
+        RFloat::Real(true, 0, Integer::from(3)),        // (true, 0, 0, 3)
+        RFloat::Real(true, 1, Integer::from(2)),        // (true, 0, 1, 2)
+        RFloat::Real(true, 1, Integer::from(3)),        // (true, 0, 1, 3)
+        RFloat::Real(true, 2, Integer::from(2)),        // (true, 0, 2, 2)
+        RFloat::Real(true, 2, Integer::from(3)),        // (true, 0, 2, 3)
+
+        RFloat::Real(true, 4, Integer::from(1)),         // (true, 1, 0, 1)
+        RFloat::Real(true, 5, Integer::from(1)),         // (true, 1, 1, 1)
+        RFloat::Real(true, 6, Integer::from(1)),         // (true, 1, 2, 1)
+        RFloat::Real(true, 7, Integer::from(1)),         // (true, 1, 3, 1)
+
+        RFloat::Real(true, 8, Integer::from(1)),         // (true, 2, 0, 1)
+        RFloat::Real(true, 10, Integer::from(1)),        // (true, 2, 2, 1)
+
+        RFloat::Real(true, 12, Integer::from(1)),        // (true, 3, 0, 1)
+        RFloat::Real(true, 16, Integer::from(1)),        // (true, 4, 0, 1)
+    ];
+
+    for (i, v) in all_vals.iter().enumerate() {
+        let num = bits_to_rfloat(&ctx, i);
+        if num.is_nar() {
+            assert!(v.is_nar(), "failed conversion: i={}, v=NAR, e={:?}", i, v);
+        } else {
+            assert_eq!(num.clone(), v.clone(), "failed conversion: i={}, v={:?}, e={:?}", i, num, v);
+        }
+    }
+}
+
+#[test]
+fn bounds() {
+    // posit<2, 8> format
     let ctx = PositContext::new(2, 8);
     assert_eq!(ctx.useed(), 16);
-    assert_eq!(RFloat::from(ctx.maxval()), RFloat::Real(false, 24, Integer::from(1)));
-    assert_eq!(RFloat::from(ctx.minval()), RFloat::Real(false, -24, Integer::from(1)));
+    assert_eq!(
+        RFloat::from(ctx.maxval()),
+        RFloat::Real(false, 24, Integer::from(1))
+    );
+    assert_eq!(
+        RFloat::from(ctx.minval()),
+        RFloat::Real(false, -24, Integer::from(1))
+    );
 }

--- a/tests/posit.rs
+++ b/tests/posit.rs
@@ -90,10 +90,33 @@ fn enumerate() {
                 v
             );
         }
+    }
+}
 
-        let f = ctx.bits_to_number(Integer::from(i));
-        let j = f.into_bits();
-        assert_eq!(i, j, "failed round-trip: i={}, j={}, v={:?}", i, j, num);
+#[test]
+fn round_trip() {
+    // posit<2, 6> format
+    let ctx = PositContext::new(2, 6);
+    for i in 0..(1 << ctx.nbits()) {
+        let num = ctx.bits_to_number(Integer::from(i));
+        let j = num.clone().into_bits();
+        assert_eq!(i, j, "round trip failed: i={}, j={}, num={:?}", i, j, num);
+    }
+
+    // posit<2, 8> format
+    let ctx = PositContext::new(2, 8);
+    for i in 0..(1 << ctx.nbits()) {
+        let num = ctx.bits_to_number(Integer::from(i));
+        let j = num.clone().into_bits();
+        assert_eq!(i, j, "round trip failed: i={}, j={}, num={:?}", i, j, num);
+    }
+
+    // posit<3, 12> format
+    let ctx = PositContext::new(3, 12);
+    for i in 0..(1 << ctx.nbits()) {
+        let num = ctx.bits_to_number(Integer::from(i));
+        let j = num.clone().into_bits();
+        assert_eq!(i, j, "round trip failed: i={}, j={}, num={:?}", i, j, num);
     }
 }
 
@@ -109,5 +132,17 @@ fn bounds() {
     assert_eq!(
         RFloat::from(ctx.minval()),
         RFloat::Real(false, -24, Integer::from(1))
+    );
+
+    // posit<3, 8> format
+    let ctx = PositContext::new(3, 8);
+    assert_eq!(ctx.useed(), 256);
+    assert_eq!(
+        RFloat::from(ctx.maxval()),
+        RFloat::Real(false, 48, Integer::from(1))
+    );
+    assert_eq!(
+        RFloat::from(ctx.minval()),
+        RFloat::Real(false, -48, Integer::from(1))
     );
 }

--- a/tests/posit.rs
+++ b/tests/posit.rs
@@ -1,0 +1,11 @@
+use mpmfnum::{posit::*, rfloat::RFloat};
+use rug::Integer;
+
+#[test]
+fn enumerate() {
+    // "Posit8" format
+    let ctx = PositContext::new(2, 8);
+    assert_eq!(ctx.useed(), 16);
+    assert_eq!(RFloat::from(ctx.maxval()), RFloat::Real(false, 24, Integer::from(1)));
+    assert_eq!(RFloat::from(ctx.minval()), RFloat::Real(false, -24, Integer::from(1)));
+}


### PR DESCRIPTION
This PR adds support for posit numbers (see the [Posit](https://posithub.org/docs/posit_standard-2.pdf) Standard). Quire numbers are left out for now, but may be included later.