### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A numbers library in Rust"
 keywords = [ "numerics", "math" ]
 categories = [ "mathematics" ]
 
-homepage = "https://github.com/bksaiki/mpmfnum-rust"
+repository = "https://github.com/bksaiki/mpmfnum-rust"
 readme = "README.md"
 license = "MIT"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.